### PR TITLE
Changed "." to "-" in pytorch module names.

### DIFF
--- a/src/i3dense.py
+++ b/src/i3dense.py
@@ -50,7 +50,7 @@ class _DenseLayer3d(torch.nn.Sequential):
                     pad_size = int(kernel_size / 2)
                     pad_time = ReplicationPad3d((0, 0, 0, 0, pad_size,
                                                  pad_size))
-                    self.add_module('padding.1', pad_time)
+                    self.add_module('padding-1', pad_time)
                     # Add time dimension of same dim as the space one
                     self.add_module(name,
                                     inflate.inflate_conv(child, kernel_size))
@@ -83,7 +83,7 @@ class _Transition3d(torch.nn.Sequential):
             elif isinstance(layer, torch.nn.Conv2d):
                 if inflate_conv:
                     pad_time = ReplicationPad3d((0, 0, 0, 0, 1, 1))
-                    self.add_module('padding.1', pad_time)
+                    self.add_module('padding-1', pad_time)
                     self.add_module(name, inflate.inflate_conv(layer, 3))
                 else:
                     self.add_module(name, inflate.inflate_conv(layer, 1))


### PR DESCRIPTION
"." are no longer allowed in pytorch module names so the densenet code doesn't work with newer pytorch versions. This can be easily changed with the proposed commit. (https://github.com/pytorch/vision/pull/474 pytorch doesnt allow "." in module names)
I first mentioned the issue in: https://github.com/hassony2/inflated_convnets_pytorch/issues/7